### PR TITLE
fix: Ci workflow to install pnpm and run scripts correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,10 @@ jobs:
           node-version: 18
           cache: 'pnpm'
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This pull request fixes the CI workflow to ensure that pnpm is properly installed before running commands. This resolves the error where pnpm was not found in the GitHub Actions environment.