### PR TITLE
fix: Ci workflow to install pnpm and run scripts correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This pull request fixes the CI workflow to ensure that pnpm is properly installed before running commands. This resolves the error where pnpm was not found in the GitHub Actions environment.