### PR TITLE
fix: Ci workflow to install pnpm and run scripts correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Verify pnpm installation
         run: pnpm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           version: 9
 
+      - name: Verify pnpm installation
+        run: pnpm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
This pull request fixes the CI workflow to ensure that pnpm is properly installed before running commands. This resolves the error where pnpm was not found in the GitHub Actions environment.